### PR TITLE
Changed compile target to es5 for IE11 support

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es6",
+    "target": "es5",
     "module": "commonjs",
     "lib": ["es2015", "es2016", "es2017", "dom"],
     "declaration": true,


### PR DESCRIPTION
For our current project we have a strong desire to make use of the library but we also need to support IE 11. With the current compile target set to es6 there is no support for IE 11. Can the compile target be changed to es5?