### PR TITLE
ES2018 build

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "sideEffects": false,
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && tsc -p tsconfig.es.json",
     "docs": "typedoc --out documentation/ src/ --theme minimal",
     "test": "jest",
     "test-watch": "jest --watch"

--- a/tsconfig.es.json
+++ b/tsconfig.es.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig",
+  "compilerOptions": {
+    "target": "es2018",
+    "lib": ["es2018", "dom"],
+    "outDir": "lib/es",
+    "downlevelIteration": false
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,5 +18,5 @@
     "downlevelIteration": true,
     "strict": true
   },
-  "exclude": ["site", "**/*.test.ts"]
+  "exclude": ["site", "**/*.test.ts", "lib"]
 }


### PR DESCRIPTION
With this setup, later could opt-in to `es` build by:

```typescript
import { Maybe } from 'purify-ts/es/Maybe'
```



resolves #126 