### PR TITLE
Use Maybe.fromNullable in Maybe example

### DIFF
--- a/site/src/data.tsx
+++ b/site/src/data.tsx
@@ -105,7 +105,7 @@ const data: Data = {
         {
           title: 'With Maybe',
           content: [
-            'const port = getConfig()',
+            'const port = Maybe.fromNullable(getConfig())',
             '    .chain(x => x.port)',
             '    .map(parseInt)',
             '    .orDefault(8080)',


### PR DESCRIPTION
If the type signature of `getConfig` does not change between examples (returning `Maybe<Config>` instead of `Config | null`), then we need to call  `Maybe.fromNullable`