### PR TITLE
[#189] Make custom Codecs support maybe codec being optional

### DIFF
--- a/src/Codec.test.ts
+++ b/src/Codec.test.ts
@@ -669,7 +669,7 @@ describe('Codec', () => {
               minItems: 1
             }
           },
-          required: ['a', 'b', 'u', 'en', 'on', 'optimal', 'e', 'm', 'n']
+          required: ['a', 'b', 'u', 'en', 'on', 'optimal', 'e', 'n']
         },
         {
           properties: {

--- a/src/Codec.ts
+++ b/src/Codec.ts
@@ -443,8 +443,8 @@ export const lazy = <T>(getCodec: () => Codec<T>): Codec<T> =>
   })
 
 /** A codec for purify's Maybe type. Encode runs Maybe#toJSON, which effectively returns the value inside if it's a Just or undefined if it's Nothing */
-export const maybe = <T>(codec: Codec<T>): Codec<Maybe<T>> =>
-  Codec.custom({
+export const maybe = <T>(codec: Codec<T>): Codec<Maybe<T>> => {
+  const baseCodec = Codec.custom({
     decode: (input: unknown) =>
       Maybe.fromNullable(input).caseOf({
         Just: (x) => codec.decode(x).map(Just),
@@ -453,9 +453,13 @@ export const maybe = <T>(codec: Codec<T>): Codec<Maybe<T>> =>
     encode: (input: Maybe<T>) => input.toJSON(),
     schema: () => ({
       oneOf: codec.schema() ? [codec.schema(), { type: 'null' }] : []
-    }),
+    })
+  });
+  return ({
+    ...baseCodec,
     _isOptional: () => true
-  } as any)
+  } as any);
+}
 
 /** A codec for purify's NEL type */
 export const nonEmptyList = <T>(codec: Codec<T>): Codec<NonEmptyList<T>> => {


### PR DESCRIPTION
The `maybe` codec added support for optional, but it looks like it doesn't quite work, as passing `_isOptional` through `custom` wipes it out. This PR fixes that.

In the longer term you'll probably want to keep a `CodecInternal` interface with these internal-use-only fields, and make shadows of these to export externally that strips the internal fields.
