### PR TITLE
make EitherAsync interface more versatile

### DIFF
--- a/src/EitherAsync.test.ts
+++ b/src/EitherAsync.test.ts
@@ -84,6 +84,19 @@ describe('EitherAsync', () => {
     expect(await newEitherAsync2.run()).toEqual(Right(0))
   })
 
+  test('mapLeft async', async () => {
+    const newEitherAsync = EitherAsync<number, never>(() =>
+      Promise.reject(0)
+    ).mapLeft(async (x) => x + 1)
+
+    const newEitherAsync2 = EitherAsync<never, number>(() =>
+      Promise.resolve(0)
+    ).mapLeft(async (x) => x + 1)
+
+    expect(await newEitherAsync).toEqual(Left(1))
+    expect(await newEitherAsync2).toEqual(Right(0))
+  })
+
   test('chain', async () => {
     const newEitherAsync = EitherAsync(() => Promise.resolve(5)).chain((_) =>
       EitherAsync(() => Promise.resolve('val'))
@@ -96,7 +109,7 @@ describe('EitherAsync', () => {
     expect(await newEitherAsync2.run()).toEqual(Right('val'))
   })
 
-  test('chain either', async () => {
+  test('chain Either', async () => {
     const chainedEitherAsync = EitherAsync(() => Promise.resolve(5)).chain(
       v => Right(v + 1)
     );
@@ -108,7 +121,7 @@ describe('EitherAsync', () => {
     expect(await failedEitherAsync).toEqual(Left('failed'));
   })
 
-  test('chain promise either', async () => {
+  test('chain Promsie<Either>', async () => {
     const chainedEitherAsync = EitherAsync(() => Promise.resolve(5)).chain(
       async (v) => Right(v + 1)
     );
@@ -127,6 +140,30 @@ describe('EitherAsync', () => {
     const newEitherAsync2 = EitherAsync<number, number>(() =>
       Promise.reject(5)
     ).chainLeft((e) => EitherAsync(() => Promise.resolve(e + 1)))
+
+    expect(await newEitherAsync.run()).toEqual(Right(5))
+    expect(await newEitherAsync2.run()).toEqual(Right(6))
+  })
+
+  test('chainLeft Either', async () => {
+    const newEitherAsync = EitherAsync(() =>
+      Promise.resolve(5)
+    ).chainLeft(_ => Right(0));
+    const newEitherAsync2 = EitherAsync<number, number>(() =>
+      Promise.reject(5)
+    ).chainLeft(v => Right(v + 1));
+
+    expect(await newEitherAsync.run()).toEqual(Right(5))
+    expect(await newEitherAsync2.run()).toEqual(Right(6))
+  })
+
+  test('chainLeft Promise<Either>', async () => {
+    const newEitherAsync = EitherAsync(() =>
+      Promise.resolve(5)
+    ).chainLeft(async _ => Right(0));
+    const newEitherAsync2 = EitherAsync<number, number>(() =>
+      Promise.reject(5)
+    ).chainLeft(async v => Right(v + 1));
 
     expect(await newEitherAsync.run()).toEqual(Right(5))
     expect(await newEitherAsync2.run()).toEqual(Right(6))

--- a/src/EitherAsync.test.ts
+++ b/src/EitherAsync.test.ts
@@ -42,6 +42,11 @@ describe('EitherAsync', () => {
     expect(await ea.run()).toEqual(Left('should show'))
   })
 
+  test('promise interface', async () => {
+    const newEitherAsync = EitherAsync(() => Promise.resolve(5));
+    expect(await newEitherAsync).toEqual(Right(5));
+  });
+
   test('map', async () => {
     const newEitherAsync = EitherAsync(() => Promise.resolve(5)).map(
       (_) => 'val'
@@ -53,6 +58,18 @@ describe('EitherAsync', () => {
     expect(await newEitherAsync.run()).toEqual(Right('val'))
     expect(await newEitherAsync2.run()).toEqual(Right('val'))
   })
+
+  test('map async', async () => {
+    const newEitherAsync = EitherAsync(() => Promise.resolve(5)).map(
+      async (_) => 'val'
+    )
+    const newEitherAsync2 = EitherAsync(() => Promise.resolve(5))[
+      'fantasy-land/map'
+    ](async (_) => 'val')
+
+    expect(await newEitherAsync.run()).toEqual(Right('val'))
+    expect(await newEitherAsync2.run()).toEqual(Right('val'))
+  });
 
   test('mapLeft', async () => {
     const newEitherAsync = EitherAsync<number, never>(() =>
@@ -77,6 +94,30 @@ describe('EitherAsync', () => {
 
     expect(await newEitherAsync.run()).toEqual(Right('val'))
     expect(await newEitherAsync2.run()).toEqual(Right('val'))
+  })
+
+  test('chain either', async () => {
+    const chainedEitherAsync = EitherAsync(() => Promise.resolve(5)).chain(
+      v => Right(v + 1)
+    );
+    expect(await chainedEitherAsync).toEqual(Right(6));
+
+    const failedEitherAsync = EitherAsync(() => Promise.resolve(5)).chain(
+      _ => Left('failed')
+    );
+    expect(await failedEitherAsync).toEqual(Left('failed'));
+  })
+
+  test('chain promise either', async () => {
+    const chainedEitherAsync = EitherAsync(() => Promise.resolve(5)).chain(
+      async (v) => Right(v + 1)
+    );
+    expect(await chainedEitherAsync).toEqual(Right(6));
+
+    const failedEitherAsync = EitherAsync(() => Promise.resolve(5)).chain(
+      async (_) => Left('failed')
+    );
+    expect(await failedEitherAsync).toEqual(Left('failed'));
   })
 
   test('chainLeft', async () => {

--- a/src/EitherAsync.test.ts
+++ b/src/EitherAsync.test.ts
@@ -45,7 +45,10 @@ describe('EitherAsync', () => {
   test('promise interface', async () => {
     const newEitherAsync = EitherAsync(() => Promise.resolve(5));
     expect(await newEitherAsync).toEqual(Right(5));
-  });
+
+    const newEitherAsync2 = EitherAsync(() => Promise.reject('nope'));
+    expect(await newEitherAsync2).toEqual(Left('nope'));
+});
 
   test('map', async () => {
     const newEitherAsync = EitherAsync(() => Promise.resolve(5)).map(

--- a/src/EitherAsync.ts
+++ b/src/EitherAsync.ts
@@ -1,7 +1,7 @@
 import { Either, Left, Right } from './Either'
 import { MaybeAsync } from './MaybeAsync'
 
-export type EitherAsyncable<L, R> = Either<L, R> | EitherAsync<L, R> | Promise<Either<L, R>>;
+export type EitherAsyncable<L, R> = Either<L, R> | Promise<Either<L, R>>;
 
 export interface EitherAsync<L, R> extends Promise<Either<L, R>> {
   /**

--- a/src/EitherAsync.ts
+++ b/src/EitherAsync.ts
@@ -1,7 +1,7 @@
 import { Either, Left, Right } from './Either'
 import { MaybeAsync } from './MaybeAsync'
 
-export interface EitherAsync<L, R> {
+export interface EitherAsync<L, R> extends Promise<Either<L, R>> {
   /**
    * It's important to remember how `run` will behave because in an
    * async context there are other ways for a function to fail other
@@ -130,6 +130,23 @@ class EitherAsyncImpl<L, R> implements EitherAsync<L, R> {
   ): EitherAsync<L, R2> {
     return this.chain(f)
   }
+
+  async then<TResult1 = Either<L, R>, TResult2 = never>(
+    onfulfilled?: ((value: Either<L, R>) => TResult1 | PromiseLike<TResult1>) | undefined | null,
+    onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null
+  ): Promise<TResult1 | TResult2> {
+    return this.run().then(onfulfilled, onrejected);
+  }
+
+  async catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): Promise<Either<L,R> | TResult> {
+    return this.run().catch(onrejected);
+  }
+
+  async finally(onfinally?: (() => void) | undefined | null): Promise<Either<L,R>> {
+    return this.run().finally(onfinally);
+  }
+
+  readonly [Symbol.toStringTag]: string;
 }
 
 /** Constructs an EitherAsync object from a function that takes an object full of helpers that let you lift things into the EitherAsync context and returns a Promise */


### PR DESCRIPTION
In my project I've been integrated Purify mostly to get the benefits of Either and Maybe. When I hit some async parts of our code I saw some potential ways to make `EitherAsync`s easier to work with. 

Specifically:
- make `EitherAsync` extend `Promise<Either>`
- `map` and `mapLeft` now work with async map functions
- `chain` and `chainLeft` now work with chain functions that return `Either` or `Promise<Either>`

Quick example. Assume you have the following operations you might want to do on your data:
```typescript
async function asyncThing(n: number): Promise<number> {
  return n + 1;
}

function eitherThing(n: number): Either<string, number> {
  return Right(n + 1);
}

async function asyncEitherThing(n: number): Promise<Either<string, number>> {
  return eitherThing(n);
}
```

Monadic chaining with the current interface would look something like:
```typescript
const n: Either<string, number> = Right(10);

const result = liftEither(n)
  .chain(value => liftEither(eitherThing(value)))
  .chain(value => fromPromise(() => asyncEitherThing(value)))
  .map(asyncThing);

  (await result.run()).map(async (n: Promise<number>) => {
    console.log('number', await n);
  });

```

With the new interface, you can do:
```typescript
const n: Either<string, number> = Right(10);

const result = liftEither(n)
  .chain(eitherThing)
  .chain(asyncEitherThing)
  .map(asyncThing);

(await result).map((n: number) => console.log('number', n));
```