### PR TITLE
remove unnecessary then in EitherAsync interface

### DIFF
--- a/src/EitherAsync.ts
+++ b/src/EitherAsync.ts
@@ -48,7 +48,7 @@ export interface EitherAsync<L, R> extends PromiseLike<Either<L, R>> {
   ): EitherAsync<L, R2>
 
   /** WARNING: This is implemented only for Promise compatibility. Please use `chain` instead. */
-  then: any
+  then: PromiseLike<Either<L, R>>['then']
 }
 
 export interface EitherAsyncValue<R> extends PromiseLike<R> {}

--- a/src/MaybeAsync.ts
+++ b/src/MaybeAsync.ts
@@ -38,7 +38,7 @@ export interface MaybeAsync<T> extends PromiseLike<Maybe<T>> {
   'fantasy-land/chain'<U>(f: (value: T) => PromiseLike<Maybe<U>>): MaybeAsync<U>
 
   /** WARNING: This is implemented only for Promise compatibility. Please use `chain` instead. */
-  then: any
+  then: PromiseLike<Maybe<T>>['then']
 }
 
 export interface MaybeAsyncValue<T> extends PromiseLike<T> {}


### PR DESCRIPTION
On 0.16.0-beta.3, was having trouble with `tsc`, an `EitherAsync` wasn't being recognized as `await`-able. Removing this `then` turned out to work; not 100% sure but I think it has to do with Typescript expecting `then` to return a promise of some sort.