### PR TITLE
Site API styling improvements

### DIFF
--- a/site/src/components/DataTypeMethod.js
+++ b/site/src/components/DataTypeMethod.js
@@ -82,11 +82,13 @@ const MethodExample = styled.div`
   border-left: 4px solid #8acefb;
   padding: 5px;
   margin: 5px 0;
+  overflow-x: scroll;
+  max-width: calc(95vw - 200px);
 
   @media only screen and (max-width: 768px) {
     white-space: nowrap;
     text-overflow: ellipsis;
-    overflow-x: scroll;
+    max-width: 100vw;
   }
 `
 

--- a/site/src/components/DataTypeMethod.js
+++ b/site/src/components/DataTypeMethod.js
@@ -29,10 +29,10 @@ const MethodName = styled.a`
 
 const MethodSignature = styled.span`
   display: inline-block;
-  font-family: Consolas;
+  font-family: Consolas, Menlo, monospace;
   background-color: #e7edf1;
   border-radius: 4px;
-  font-size: 14px;
+  font-size: 0.8rem;
   margin-right: 10px;
   margin-bottom: 10px;
 
@@ -42,7 +42,7 @@ const MethodSignature = styled.span`
     color: white;
     border-bottom-left-radius: 4px;
     border-top-left-radius: 4px;
-    padding: 0 5px;
+    padding: 3px 5px;
     display: inline-block;
     min-width: 13px;
     text-align: center;


### PR DESCRIPTION
This PR improves styling a bit in the site's API docs:

- Improved font compatibility for `MethodSignature` across OSes (Menlo, monospace as fallbacks when Consolas not present)
- Set a max width for code examples to improve responsiveness

Best page to view these changes is `/utils/Codec`