### PR TITLE
Map codec and some all functions for EitherAsync

### DIFF
--- a/src/Codec.test.ts
+++ b/src/Codec.test.ts
@@ -9,6 +9,7 @@ import {
   array,
   record,
   exactly,
+  map,
   maybe,
   nonEmptyList,
   tuple,
@@ -291,6 +292,30 @@ describe('Codec', () => {
       expect(record(mockKeyCodec, mockValueCodec).encode({ a: 0 })).toEqual({
         haha: 1
       })
+    })
+  })
+
+  describe('map', () => {
+    const mockCodec = map(string, number)
+
+    const pairs = [
+      ['a', 1],
+      ['b', 2],
+      ['c', 3]
+    ] as const
+
+    test('decode', () => {
+      const decodedMap = mockCodec.decode(pairs)
+
+      expect(decodedMap.map((m) => m.get('a'))).toEqual(Right(1))
+      expect(decodedMap.map((m) => m.get('b'))).toEqual(Right(2))
+      expect(decodedMap.map((m) => m.get('c'))).toEqual(Right(3))
+    })
+
+    test('encode', () => {
+      const encodedMap = mockCodec.encode(new Map(pairs))
+
+      expect(encodedMap).toEqual(pairs)
     })
   })
 

--- a/src/Codec.ts
+++ b/src/Codec.ts
@@ -430,6 +430,27 @@ export const record = <K extends keyof any, V>(
     })
   })
 
+/** A codec for ES6 Maps, which represents keys and values into tuples */
+export const map = <K, V>(
+  keyCodec: Codec<K>,
+  valueCodec: Codec<V>
+): Codec<Map<K, V>> =>
+  Codec.custom({
+    decode: (value) =>
+      array(tuple([keyCodec, valueCodec]))
+        .decode(value)
+        .map((pairs) => new Map(pairs)),
+    encode: (value) =>
+      Array.from(value.entries()).map(([k, v]) => [
+        keyCodec.encode(k),
+        valueCodec.encode(v)
+      ]),
+    schema: () => ({
+      type: 'object',
+      additionalProperties: valueCodec.schema()
+    })
+  })
+
 /** A codec that only succeeds decoding when the value is exactly what you've constructed the codec with */
 export const exactly = <T extends string | number | boolean>(
   expectedValue: T

--- a/src/EitherAsync.test.ts
+++ b/src/EitherAsync.test.ts
@@ -433,4 +433,20 @@ describe('EitherAsync', () => {
 
     expect(await ea).toEqual(Left('AAA'))
   })
+
+  test('all static', async () => {
+    expect(
+      await EitherAsync.all([
+        EitherAsync.liftEither(Right(1)),
+        EitherAsync.liftEither(Right(2))
+      ]).run()
+    ).toEqual(Right([1, 2]))
+
+    expect(
+      await EitherAsync.all2([
+        EitherAsync.liftEither(Right(1)),
+        EitherAsync.liftEither(Right('hello'))
+      ]).run()
+    ).toEqual(Right([1, 'hello']))
+  })
 })

--- a/src/EitherAsync.ts
+++ b/src/EitherAsync.ts
@@ -292,11 +292,7 @@ export const EitherAsync: EitherAsyncTypeRef = Object.assign(
         return helpers.liftEither(Right(res))
       }),
     all: <L, R>(eitherAsyncs: EitherAsync<L, R>[]): EitherAsync<L, R[]> =>
-      EitherAsync.fromPromise(() =>
-        Promise.all(eitherAsyncs.map((eitherAsync) => eitherAsync.run())).then(
-          Either.sequence
-        )
-      ),
+      EitherAsync.sequence(eitherAsyncs),
     all2: <L, R1, R2>([ea1, ea2]: [
       EitherAsync<L, R1>,
       EitherAsync<L, R2>


### PR DESCRIPTION
Apologies for these being in a single pull request - let me know if you want them to be split up.

This adds a codec for a `Map`, as well as helper functions for combining multiple `EitherAsync`s into a single `EitherAsync` that returns the result of either as a typed element on an array.