### PR TITLE
Enable es6 module export

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Functional programming standard library for TypeScript ",
   "main": "index.js",
   "types": "index.d.ts",
+  "module": "es/index.js",
   "repository": "https://github.com/gigobyte/purify.git",
   "author": "gigobyte <gigobest2@gmail.com>",
   "license": "ISC",

--- a/tsconfig.es.json
+++ b/tsconfig.es.json
@@ -3,6 +3,8 @@
   "compilerOptions": {
     "target": "es2018",
     "lib": ["es2018", "dom"],
+    "module": "ESNext",
+    "moduleResolution": "node",
     "outDir": "lib/es",
     "downlevelIteration": false
   }


### PR DESCRIPTION
ES module support appears to be broken. This small fix will make it work again.