### PR TITLE
Codec: improve optional property field type

### DIFF
--- a/src/Codec.ts
+++ b/src/Codec.ts
@@ -112,8 +112,21 @@ export const Codec = {
     properties: T
   ): Codec<
     {
-      [k in keyof T]: GetType<T[k]>
-    }
+      [K in keyof Pick<
+        T,
+        {
+          [Key in keyof T]-?: undefined extends GetType<T[Key]> ? never : Key
+        }[keyof T]
+      >]: GetType<T[K]>
+    } &
+      {
+        [K in keyof Pick<
+          T,
+          {
+            [Key in keyof T]-?: undefined extends GetType<T[Key]> ? Key : never
+          }[keyof T]
+        >]?: Exclude<GetType<T[K]>, undefined>
+      }
   > {
     const keys = Object.keys(properties)
 


### PR DESCRIPTION
Currently `Codec.interface` with optional property infers to type union with undefined.

```typescript
const MyCodec = Codec.interface({
  a: string,
  b: optional(string)
});
type MyCodecType = GetType<typeof MyCodec>
// MyCodecType is { a: string, b: string | undefined }
```

This behavior is bit inconvenience, because declaring value with codec type annotation must requires undefined to optional property.

```typescript
const myValue1: MyCodecType = { a: "" } // compile error
const myValue2: MyCodecType = { a: "", b: 0 } // ok
```

This pull request changes that type inferences.
New type inference of MyCodecType is `{ a: string } & { b?: string | undefined }`.