### PR TITLE
fix(CurriedFn) export type

### DIFF
--- a/src/Function.ts
+++ b/src/Function.ts
@@ -38,7 +38,7 @@ export const orderToNumber = (order: Order): number => {
 
 type TupleOfLength<T extends any[]> = Extract<{ [K in keyof T]: any }, any[]>
 
-type CurriedFn<TAllArgs extends any[], TReturn> = <
+export type CurriedFn<TAllArgs extends any[], TReturn> = <
   TProvidedArgs extends TAllArgs extends [infer TFirstArg, ...infer TRestOfArgs]
     ? [TFirstArg, ...Partial<TRestOfArgs>]
     : never


### PR DESCRIPTION
I'm getting this error when trying to  use the curry utility function

 `Exported variable 'myCurriedfn' has or is using name 'CurriedFn' from external module "/path/node_modules/purify-ts/Function" but cannot be named.ts(4023).
`

This solves it