### PR TITLE
Display correct project version number in docs

### DIFF
--- a/site/src/components/Sidebar.js
+++ b/site/src/components/Sidebar.js
@@ -54,7 +54,7 @@ class Sidebar extends React.Component {
       <Container>
         <Header>
           <HeaderTitle to="/">Purify</HeaderTitle>
-          <HeaderTitleVersion>v0.16</HeaderTitleVersion>
+          <HeaderTitleVersion>v1.1.0</HeaderTitleVersion>
           <HamburgerMenu
             onClick={this.toggleMenu}
             opened={this.state.isMenuShown}


### PR DESCRIPTION
Hello,

I noticed the version displayed in the documentation was not the last one, so here is a quick fix 🙂