### PR TITLE
[Symbol.iterator]() for Either and Maybe

### DIFF
--- a/src/Either.test.ts
+++ b/src/Either.test.ts
@@ -277,4 +277,28 @@ describe('Either', () => {
     expect(Right(5).swap()).toEqual(Left(5))
     expect(Left(5).swap()).toEqual(Right(5))
   })
+
+  test('iterator', () => {
+    let a = 0
+    let i = 0
+    for (const n of Right(5)) {
+      a = 5
+      i++
+    }
+    expect(a).toEqual(5)
+    expect(i).toEqual(1)
+
+    let b = 0
+    let j = 0
+    for (const n of Left('Error')) {
+      b = 5
+      j++
+    }
+    expect(b).toEqual(0)
+    expect(j).toEqual(0)
+
+    const arr = [...Right(5), ...Left('Error'), ...Right(7)]
+    expect(arr).toEqual([5, 7])
+
+  })
 })

--- a/src/Either.ts
+++ b/src/Either.ts
@@ -63,6 +63,9 @@ export interface Either<L, R> {
   /** Returns `Right` if `this` is `Left` and vice versa */
   swap(): Either<R, L>
 
+  /** Returns an iterator over the possibly contained value. The iterator yields one value if `this` is `Right`, otherwise none */
+  [Symbol.iterator](): Iterator<R>
+
   'fantasy-land/bimap'<L2, R2>(
     f: (value: L) => L2,
     g: (value: R) => R2
@@ -272,6 +275,10 @@ class Right<R, L = never> implements Either<L, R> {
     return left(this.__value)
   }
 
+  *[Symbol.iterator]() {
+    yield this.__value
+  }
+
   'fantasy-land/bimap' = this.bimap
   'fantasy-land/map' = this.map
   'fantasy-land/ap' = this.ap
@@ -408,6 +415,8 @@ class Left<L, R = never> implements Either<L, R> {
   swap(): Either<R, L> {
     return right(this.__value)
   }
+
+  *[Symbol.iterator]() {}
 
   'fantasy-land/bimap' = this.bimap
   'fantasy-land/map' = this.map

--- a/src/Maybe.test.ts
+++ b/src/Maybe.test.ts
@@ -261,4 +261,28 @@ describe('Maybe', () => {
     expect(Just(5).filter((x) => x > 0)).toEqual(Just(5))
     expect(Nothing.filter((x) => x > 0)).toEqual(Nothing)
   })
+
+  test('iterator', () => {
+    let a = 0
+    let i = 0
+    for (const n of Just(5)) {
+      a = 5
+      i++
+    }
+    expect(a).toEqual(5)
+    expect(i).toEqual(1)
+
+    let b = 0
+    let j = 0
+    for (const n of Nothing) {
+      b = 5
+      j++
+    }
+    expect(b).toEqual(0)
+    expect(j).toEqual(0)
+
+    const arr = [...Just(5), ...Nothing, ...Just(7)]
+    expect(arr).toEqual([5, 7])
+
+  })
 })

--- a/src/Maybe.ts
+++ b/src/Maybe.ts
@@ -65,6 +65,9 @@ export interface Maybe<T> {
   /** Takes a predicate function and returns `this` if the predicate returns true or Nothing if it returns false */
   filter(pred: (value: T) => boolean): Maybe<T>
 
+  /** Returns an iterator over the possibly contained value. */
+  [Symbol.iterator](): Iterator<T>
+
   'fantasy-land/equals'(other: Maybe<T>): boolean
   'fantasy-land/map'<U>(f: (value: T) => U): Maybe<U>
   'fantasy-land/ap'<U>(maybeF: Maybe<(value: T) => U>): Maybe<U>
@@ -303,6 +306,10 @@ class Just<T> implements Maybe<T> {
     return pred(this.__value) ? just(this.__value) : nothing
   }
 
+  *[Symbol.iterator]() {
+    yield this.__value
+  }
+
   'fantasy-land/equals' = this.equals
   'fantasy-land/map' = this.map
   'fantasy-land/ap' = this.ap
@@ -429,6 +436,8 @@ class Nothing implements Maybe<never> {
   filter(_: (value: never) => boolean): Maybe<never> {
     return nothing
   }
+
+  *[Symbol.iterator]() {}
 
   'fantasy-land/equals' = this.equals
   'fantasy-land/map' = this.map


### PR DESCRIPTION
Iterator implementations for This is one thing I personally love about Rust's monadic ADTs that I felt was missing in Purify. 

This addition allows for the following:
```ts
const foo = Right(5)
for (const five of foo) {
    // Do something with `five`
}
```

As well as in other libraries whose operators are capable of using iterators, such as [Rx](https://xgrommx.github.io/rx-book/content/getting_started_with_rxjs/creating_and_querying_observable_sequences/generators_and_observable_sequences.html)
```ts
const bar = Right(5)
Rx.Observable.from(bar)
  .take(1)
  .subscribe(x => console.log('Value: ' + x))
  // "Value: 5"
```
Allowing for some interesting interoperability. 

This PR adds `[Symbol.iterator]()` method implemenations for `Maybe` and `Either` and includes test coverage.
