### PR TITLE
Fix EitherAsync.mapLeft not awaiting result

### DIFF
--- a/src/EitherAsync.test.ts
+++ b/src/EitherAsync.test.ts
@@ -88,8 +88,13 @@ describe('EitherAsync', () => {
       Promise.resolve(0)
     ).mapLeft((x) => x + 1)
 
+    const newEitherAsync3 = EitherAsync.fromPromise(() =>
+      Promise.resolve(Left(2))
+    ).mapLeft(async (i) => i + 1)
+
     expect(await newEitherAsync.run()).toEqual(Left(1))
     expect(await newEitherAsync2.run()).toEqual(Right(0))
+    expect(await newEitherAsync3.run()).toEqual(Left(3))
   })
 
   test('chain', async () => {

--- a/src/EitherAsync.ts
+++ b/src/EitherAsync.ts
@@ -213,7 +213,7 @@ class EitherAsyncImpl<L, R> implements EitherAsync<L, R> {
       try {
         return await this.runPromise(helpers as any as EitherAsyncHelpers<L>)
       } catch (e: any) {
-        throw f(e)
+        throw await f(e)
       }
     })
   }


### PR DESCRIPTION
Hi, very nice library!

I discovered what I believe to be an error, mapLeft in EitherAsync does never actually await the result, so I added an await. Added a test that would fail prior as well.