### PR TITLE
Fix: update types for typescript 5.5 support

### DIFF
--- a/src/Either.ts
+++ b/src/Either.ts
@@ -156,11 +156,11 @@ class Right<R, L = never> implements Either<L, R> {
 
   constructor(private __value: R) {}
 
-  isLeft(): false {
+  isLeft(): this is Either<L, never> {
     return false
   }
 
-  isRight(): true {
+  isRight(): this is Either<never, R> {
     return true
   }
 
@@ -282,6 +282,7 @@ class Right<R, L = never> implements Either<L, R> {
   'fantasy-land/extend' = this.extend
 }
 
+
 Right.prototype.constructor = Either as any
 
 class Left<L, R = never> implements Either<L, R> {
@@ -289,11 +290,11 @@ class Left<L, R = never> implements Either<L, R> {
 
   constructor(private __value: L) {}
 
-  isLeft(): true {
+  isLeft(): this is Either<L, never> {
     return true
   }
 
-  isRight(): false {
+  isRight(): this is Either<never, R> {
     return false
   }
 

--- a/src/Maybe.ts
+++ b/src/Maybe.ts
@@ -191,11 +191,11 @@ export const Maybe: MaybeTypeRef = {
 class Just<T> implements Maybe<T> {
   constructor(private __value: T) {}
 
-  isJust(): boolean {
+  isJust(): this is AlwaysJust {
     return true
   }
 
-  isNothing(): boolean {
+  isNothing(): this is Nothing {
     return false
   }
 
@@ -319,11 +319,11 @@ Just.prototype.constructor = Maybe as any
 class Nothing implements Maybe<never> {
   private __value!: never
 
-  isJust() {
+  isJust(): this is AlwaysJust {
     return false
   }
 
-  isNothing() {
+  isNothing(): this is Nothing {
     return true
   }
 


### PR DESCRIPTION
Typescript 5.5 changed the assignability of type predicates - it means that `isJust(): true` is no longer a subtype of `isJust(): this is AlwaysJust`

This PR adds type predicates to Either and Maybe (which are the only two types affected)

# Major caveat
I am worried this might be a breaking change. As far as I can tell, there is no way to achieve the old behaviour of knowing at compile-time that a Just returns `true` (as const) from `isJust`

