### PR TITLE
Move fantasy-land methods to the prototypes and implement Node.js inspect()

### DIFF
--- a/src/Either.ts
+++ b/src/Either.ts
@@ -272,16 +272,24 @@ class Right<R, L = never> implements Either<L, R> {
     return left(this.__value)
   }
 
-  'fantasy-land/bimap' = this.bimap
-  'fantasy-land/map' = this.map
-  'fantasy-land/ap' = this.ap
-  'fantasy-land/equals' = this.equals
-  'fantasy-land/chain' = this.chain
-  'fantasy-land/alt' = this.alt
-  'fantasy-land/reduce' = this.reduce
-  'fantasy-land/extend' = this.extend
+  declare 'fantasy-land/bimap': typeof this.bimap
+  declare 'fantasy-land/map': typeof this.map
+  declare 'fantasy-land/ap': typeof this.ap
+  declare 'fantasy-land/equals': typeof this.equals
+  declare 'fantasy-land/chain': typeof this.chain
+  declare 'fantasy-land/alt': typeof this.alt
+  declare 'fantasy-land/reduce': typeof this.reduce
+  declare 'fantasy-land/extend': typeof this.extend
 }
 
+Right.prototype['fantasy-land/bimap'] = Right.prototype.bimap
+Right.prototype['fantasy-land/map'] = Right.prototype.map
+Right.prototype['fantasy-land/ap'] = Right.prototype.ap
+Right.prototype['fantasy-land/equals'] = Right.prototype.equals
+Right.prototype['fantasy-land/chain'] = Right.prototype.chain
+Right.prototype['fantasy-land/alt'] = Right.prototype.alt
+Right.prototype['fantasy-land/reduce'] = Right.prototype.reduce
+Right.prototype['fantasy-land/extend'] = Right.prototype.extend
 Right.prototype.constructor = Either as any
 
 class Left<L, R = never> implements Either<L, R> {
@@ -409,16 +417,24 @@ class Left<L, R = never> implements Either<L, R> {
     return right(this.__value)
   }
 
-  'fantasy-land/bimap' = this.bimap
-  'fantasy-land/map' = this.map
-  'fantasy-land/ap' = this.ap
-  'fantasy-land/equals' = this.equals
-  'fantasy-land/chain' = this.chain
-  'fantasy-land/alt' = this.alt
-  'fantasy-land/reduce' = this.reduce
-  'fantasy-land/extend' = this.extend
+  declare 'fantasy-land/bimap': typeof this.bimap
+  declare 'fantasy-land/map': typeof this.map
+  declare 'fantasy-land/ap': typeof this.ap
+  declare 'fantasy-land/equals': typeof this.equals
+  declare 'fantasy-land/chain': typeof this.chain
+  declare 'fantasy-land/alt': typeof this.alt
+  declare 'fantasy-land/reduce': typeof this.reduce
+  declare 'fantasy-land/extend': typeof this.extend
 }
 
+Left.prototype['fantasy-land/bimap'] = Left.prototype.bimap
+Left.prototype['fantasy-land/map'] = Left.prototype.map
+Left.prototype['fantasy-land/ap'] = Left.prototype.ap
+Left.prototype['fantasy-land/equals'] = Left.prototype.equals
+Left.prototype['fantasy-land/chain'] = Left.prototype.chain
+Left.prototype['fantasy-land/alt'] = Left.prototype.alt
+Left.prototype['fantasy-land/reduce'] = Left.prototype.reduce
+Left.prototype['fantasy-land/extend'] = Left.prototype.extend
 Left.prototype.constructor = Either as any
 
 const left = <L, R = never>(value: L): Either<L, R> => new Left(value)

--- a/src/Either.ts
+++ b/src/Either.ts
@@ -172,6 +172,14 @@ class Right<R, L = never> implements Either<L, R> {
     return `Right(${this.__value})`
   }
 
+  [Symbol.for('nodejs.util.inspect.custom')](
+    _depth: number,
+    opts: unknown,
+    inspect: Function
+  ) {
+    return `Right(${inspect(this.__value, opts)})`
+  }
+
   toString(): string {
     return this.inspect()
   }
@@ -311,6 +319,14 @@ class Left<L, R = never> implements Either<L, R> {
 
   inspect(): string {
     return `Left(${JSON.stringify(this.__value)})`
+  }
+
+  [Symbol.for('nodejs.util.inspect.custom')](
+    _depth: number,
+    opts: unknown,
+    inspect: Function
+  ) {
+    return `Left(${inspect(this.__value, opts)})`
   }
 
   toString(): string {

--- a/src/EitherAsync.ts
+++ b/src/EitherAsync.ts
@@ -296,13 +296,17 @@ class EitherAsyncImpl<L, R> implements EitherAsync<L, R> {
     )
   }
 
-  'fantasy-land/chain' = this.chain
-  'fantasy-land/alt' = this.alt
+  declare 'fantasy-land/chain': typeof this.chain
+  declare 'fantasy-land/alt': typeof this.alt
 
   then: PromiseLike<Either<L, R>>['then'] = (onfulfilled, onrejected) => {
     return this.run().then(onfulfilled, onrejected)
   }
 }
+
+EitherAsyncImpl.prototype['fantasy-land/chain'] =
+  EitherAsyncImpl.prototype.chain
+EitherAsyncImpl.prototype['fantasy-land/alt'] = EitherAsyncImpl.prototype.alt
 
 export const EitherAsync: EitherAsyncTypeRef = Object.assign(
   <L, R>(

--- a/src/Maybe.ts
+++ b/src/Maybe.ts
@@ -203,6 +203,14 @@ class Just<T> implements Maybe<T> {
     return `Just(${this.__value})`
   }
 
+  [Symbol.for('nodejs.util.inspect.custom')](
+    _depth: number,
+    opts: unknown,
+    inspect: Function
+  ) {
+    return `Just(${inspect(this.__value, opts)})`
+  }
+
   toString(): string {
     return this.inspect()
   }
@@ -336,6 +344,10 @@ class Nothing implements Maybe<never> {
   }
 
   inspect(): string {
+    return 'Nothing'
+  }
+
+  [Symbol.for('nodejs.util.inspect.custom')]() {
     return 'Nothing'
   }
 

--- a/src/Maybe.ts
+++ b/src/Maybe.ts
@@ -304,16 +304,24 @@ class Just<T> implements Maybe<T> {
     return pred(this.__value) ? just(this.__value) : nothing
   }
 
-  'fantasy-land/equals' = this.equals
-  'fantasy-land/map' = this.map
-  'fantasy-land/ap' = this.ap
-  'fantasy-land/alt' = this.alt
-  'fantasy-land/chain' = this.chain
-  'fantasy-land/reduce' = this.reduce
-  'fantasy-land/extend' = this.extend
-  'fantasy-land/filter' = this.filter
+  declare 'fantasy-land/equals': typeof this.equals
+  declare 'fantasy-land/map': typeof this.map
+  declare 'fantasy-land/ap': typeof this.ap
+  declare 'fantasy-land/alt': typeof this.alt
+  declare 'fantasy-land/chain': typeof this.chain
+  declare 'fantasy-land/reduce': typeof this.reduce
+  declare 'fantasy-land/extend': typeof this.extend
+  declare 'fantasy-land/filter': typeof this.filter
 }
 
+Just.prototype['fantasy-land/equals'] = Just.prototype.equals
+Just.prototype['fantasy-land/map'] = Just.prototype.map
+Just.prototype['fantasy-land/ap'] = Just.prototype.ap
+Just.prototype['fantasy-land/alt'] = Just.prototype.alt
+Just.prototype['fantasy-land/chain'] = Just.prototype.chain
+Just.prototype['fantasy-land/reduce'] = Just.prototype.reduce
+Just.prototype['fantasy-land/extend'] = Just.prototype.extend
+Just.prototype['fantasy-land/filter'] = Just.prototype.filter
 Just.prototype.constructor = Maybe as any
 
 class Nothing implements Maybe<never> {
@@ -431,16 +439,24 @@ class Nothing implements Maybe<never> {
     return nothing
   }
 
-  'fantasy-land/equals' = this.equals
-  'fantasy-land/map' = this.map
-  'fantasy-land/ap' = this.ap
-  'fantasy-land/alt' = this.alt
-  'fantasy-land/chain' = this.chain
-  'fantasy-land/reduce' = this.reduce
-  'fantasy-land/extend' = this.extend
-  'fantasy-land/filter' = this.filter
+  declare 'fantasy-land/equals': typeof this.equals
+  declare 'fantasy-land/map': typeof this.map
+  declare 'fantasy-land/ap': typeof this.ap
+  declare 'fantasy-land/alt': typeof this.alt
+  declare 'fantasy-land/chain': typeof this.chain
+  declare 'fantasy-land/reduce': typeof this.reduce
+  declare 'fantasy-land/extend': typeof this.extend
+  declare 'fantasy-land/filter': typeof this.filter
 }
 
+Nothing.prototype['fantasy-land/equals'] = Nothing.prototype.equals
+Nothing.prototype['fantasy-land/map'] = Nothing.prototype.map
+Nothing.prototype['fantasy-land/ap'] = Nothing.prototype.ap
+Nothing.prototype['fantasy-land/alt'] = Nothing.prototype.alt
+Nothing.prototype['fantasy-land/chain'] = Nothing.prototype.chain
+Nothing.prototype['fantasy-land/reduce'] = Nothing.prototype.reduce
+Nothing.prototype['fantasy-land/extend'] = Nothing.prototype.extend
+Nothing.prototype['fantasy-land/filter'] = Nothing.prototype.filter
 Nothing.prototype.constructor = Maybe as any
 
 /** Constructs a Just. Represents an optional value that exists */

--- a/src/MaybeAsync.ts
+++ b/src/MaybeAsync.ts
@@ -223,10 +223,6 @@ class MaybeAsyncImpl<T> implements MaybeAsync<T> {
     )
   }
 
-  'fantasy-land/chain' = this.chain
-  'fantasy-land/filter' = this.filter
-  'fantasy-land/alt' = this.alt
-
   then<TResult1 = Maybe<T>, TResult2 = never>(
     onfulfilled?:
       | ((value: Maybe<T>) => TResult1 | PromiseLike<TResult1>)
@@ -239,7 +235,16 @@ class MaybeAsyncImpl<T> implements MaybeAsync<T> {
   ): PromiseLike<TResult1 | TResult2> {
     return this.run().then(onfulfilled, onrejected)
   }
+
+  declare 'fantasy-land/chain': typeof this.chain
+  declare 'fantasy-land/filter': typeof this.filter
+  declare 'fantasy-land/alt': typeof this.alt
 }
+
+MaybeAsyncImpl.prototype['fantasy-land/chain'] = MaybeAsyncImpl.prototype.chain
+MaybeAsyncImpl.prototype['fantasy-land/filter'] =
+  MaybeAsyncImpl.prototype.filter
+MaybeAsyncImpl.prototype['fantasy-land/alt'] = MaybeAsyncImpl.prototype.alt
 
 export const MaybeAsync: MaybeAsyncTypeRef = Object.assign(
   <T>(

--- a/src/Tuple.ts
+++ b/src/Tuple.ts
@@ -65,7 +65,10 @@ class TupleImpl<F, S> implements Tuple<F, S> {
   [index: number]: F | S
   length: 2 = 2
 
-  constructor(private first: F, private second: S) {
+  constructor(
+    private first: F,
+    private second: S
+  ) {
     this[0] = first
     this[1] = second
   }
@@ -137,12 +140,18 @@ class TupleImpl<F, S> implements Tuple<F, S> {
     return pred(this.first) || pred(this.second)
   }
 
-  'fantasy-land/equals' = this.equals
-  'fantasy-land/bimap' = this.bimap
-  'fantasy-land/map' = this.map
-  'fantasy-land/reduce' = this.reduce
-  'fantasy-land/ap' = this.ap
+  declare 'fantasy-land/equals': typeof this.equals
+  declare 'fantasy-land/bimap': typeof this.bimap
+  declare 'fantasy-land/map': typeof this.map
+  declare 'fantasy-land/reduce': typeof this.reduce
+  declare 'fantasy-land/ap': typeof this.ap
 }
+
+TupleImpl.prototype['fantasy-land/equals'] = TupleImpl.prototype.equals
+TupleImpl.prototype['fantasy-land/bimap'] = TupleImpl.prototype.bimap
+TupleImpl.prototype['fantasy-land/map'] = TupleImpl.prototype.map
+TupleImpl.prototype['fantasy-land/reduce'] = TupleImpl.prototype.reduce
+TupleImpl.prototype['fantasy-land/ap'] = TupleImpl.prototype.ap
 
 export const Tuple: TupleTypeRef = Object.assign(
   <F, S>(fst: F, snd: S) => new TupleImpl(fst, snd),

--- a/src/Tuple.ts
+++ b/src/Tuple.ts
@@ -88,6 +88,14 @@ class TupleImpl<F, S> implements Tuple<F, S> {
     )})`
   }
 
+  [Symbol.for('nodejs.util.inspect.custom')](
+    _depth: number,
+    opts: unknown,
+    inspect: Function
+  ) {
+    return `Tuple(${inspect(this.first, opts)}, ${inspect(this.second, opts)})`
+  }
+
   toString(): string {
     return this.inspect()
   }


### PR DESCRIPTION
hi! this PR closes #745 and closes #744.

here's an example of how the changes affect debugging output. given this script:
```ts
console.log('nothing:', Nothing)
console.log('something:', Just({ a: 3 }))
```

before this PR, the output was:

<details>
<summary>(expand)</summary>

```ts
nothing: {
  'fantasy-land/equals': [Function: equals],
  'fantasy-land/map': [Function: map],
  'fantasy-land/ap': [Function: ap],
  'fantasy-land/alt': [Function: alt],
  'fantasy-land/chain': [Function: chain],
  'fantasy-land/reduce': [Function: reduce],
  'fantasy-land/extend': [Function: extend],
  'fantasy-land/filter': [Function: filter]
}
something: {
  __value: { a: 3 },
  'fantasy-land/equals': [Function: equals],
  'fantasy-land/map': [Function: map],
  'fantasy-land/ap': [Function: ap],
  'fantasy-land/alt': [Function: alt],
  'fantasy-land/chain': [Function: chain],
  'fantasy-land/reduce': [Function: reduce],
  'fantasy-land/extend': [Function: extend],
  'fantasy-land/filter': [Function: filter]
}
```

</details>

after a37c7c9 (fantasy-land), and in the browser, the output is:

```ts
nothing: {}
something: { __value: { a: 3 } }
```

after a7e20f0 (inspect), only on node.js, the output is:

```ts
nothing: Nothing
something: Just({ a: 3 })
```

compare with the current `inspect()`:
```
nothing: Nothing
something: Just([object Object])
```