### PR TITLE
fix(Codec): fix crash on prototype-less objects

### DIFF
--- a/src/Codec.test.ts
+++ b/src/Codec.test.ts
@@ -66,6 +66,16 @@ describe('Codec', () => {
       expect(mockCodec.decode({ a: 0, b: '', c: '' })).toEqual(
         Right({ a: 0, b: '', c: '' })
       )
+      expect(
+        mockCodec.decode(
+          (() => {
+            const res: any = Object.create(null)
+            res.a = 0
+            res.b = 'woo'
+            return res
+          })()
+        )
+      ).toEqual(Right({ a: 0, b: 'woo' }))
     })
 
     test('unsafeDecode', () => {
@@ -295,6 +305,16 @@ describe('Codec', () => {
       expect(numberRecord.decode({})).toEqual(Right({}))
       expect(numberRecord.decode({ a: 0 })).toEqual(Right({ a: 0 }))
       expect(numberRecord.decode({ a: 0, b: 1 })).toEqual(Right({ a: 0, b: 1 }))
+      expect(
+        numberRecord.decode(
+          (() => {
+            const res: any = Object.create(null)
+            res.a = 0
+            res.b = -50
+            return res
+          })()
+        )
+      ).toEqual(Right({ a: 0, b: -50 }))
     })
 
     test('decode with number key', () => {
@@ -323,6 +343,15 @@ describe('Codec', () => {
       expect(record(mockKeyCodec, mockValueCodec).encode({ a: 0 })).toEqual({
         haha: 1
       })
+      expect(
+        record(string, string).encode(
+          (() => {
+            const res: Record<string, string> = Object.create(null)
+            res.hi = 'bye'
+            return res
+          })()
+        )
+      ).toEqual({ hi: 'bye' })
     })
   })
 

--- a/src/Codec.ts
+++ b/src/Codec.ts
@@ -47,8 +47,8 @@ const reportError = (expectedType: string, input: unknown): string => {
         input === null
           ? 'null'
           : Array.isArray(input)
-          ? 'an array with value ' + JSON.stringify(input, serializeValue)
-          : 'an object with value ' + JSON.stringify(input, serializeValue)
+            ? 'an array with value ' + JSON.stringify(input, serializeValue)
+            : 'an object with value ' + JSON.stringify(input, serializeValue)
       break
 
     case 'boolean':
@@ -129,7 +129,7 @@ export const Codec = {
 
       for (const key of keys) {
         if (
-          !input.hasOwnProperty(key) &&
+          !Object.prototype.hasOwnProperty.call(input, key) &&
           !(properties[key] as any)._isOptional
         ) {
           return Left(
@@ -254,7 +254,7 @@ export const optional = <T>(codec: Codec<T>): Codec<T | undefined> =>
     ...oneOf([codec, undefinedType]),
     schema: codec.schema,
     _isOptional: true
-  } as any)
+  }) as any
 
 /** A codec for a value T or null. Keep in mind if you use `nullable` inside `Codec.interface` the property will still be required */
 export const nullable = <T>(codec: Codec<T>): Codec<T | null> =>
@@ -397,7 +397,7 @@ export const record = <K extends keyof any, V>(
       }
 
       for (const key of Object.keys(input)) {
-        if (input.hasOwnProperty(key)) {
+        if (Object.prototype.hasOwnProperty.call(input, key)) {
           const decodedKey = keyCodecOverride.decode(key)
           const decodedValue = valueCodec.decode((input as any)[key])
 
@@ -421,7 +421,7 @@ export const record = <K extends keyof any, V>(
       const result = {} as Record<K, V>
 
       for (const key in input) {
-        if (input.hasOwnProperty(key)) {
+        if (Object.prototype.hasOwnProperty.call(input, key)) {
           result[keyCodec.encode(key) as K] = valueCodec.encode(input[key]) as V
         }
       }

--- a/src/Maybe.test.ts
+++ b/src/Maybe.test.ts
@@ -46,13 +46,21 @@ describe('Maybe', () => {
   })
 
   test('fromPredicate with guards', () => {
-    const isNotEmpty = <T>(value: T[] | null): value is [T, ...T[]] => Array.isArray(value) && value.length > 0
-    expect(Maybe.fromPredicate(isNotEmpty, null as number[] | null)).toEqual(Nothing)
-    expect(Maybe.fromPredicate(isNotEmpty, Array<number>()).map(([x]) => x)).toEqual(Nothing)
-    expect(Maybe.fromPredicate(isNotEmpty, [1]).map(([x]) => x)).toEqual(Just(1))
-    const isString = (value: string|number): value is string => typeof value === 'string'
+    const isNotEmpty = <T>(value: T[] | null): value is [T, ...T[]] =>
+      Array.isArray(value) && value.length > 0
+    expect(Maybe.fromPredicate(isNotEmpty, null as number[] | null)).toEqual(
+      Nothing
+    )
+    expect(
+      Maybe.fromPredicate(isNotEmpty, Array<number>()).map(([x]) => x)
+    ).toEqual(Nothing)
+    expect(Maybe.fromPredicate(isNotEmpty, [1]).map(([x]) => x)).toEqual(
+      Just(1)
+    )
+    const isString = (value: string | number): value is string =>
+      typeof value === 'string'
     expect(Maybe.fromPredicate(isString, 2)).toEqual(Nothing)
-    expect(Maybe.fromPredicate(isString, 'a')).toEqual(Just("a"))
+    expect(Maybe.fromPredicate(isString, 'a')).toEqual(Just('a'))
   })
 
   test('empty', () => {

--- a/src/Maybe.ts
+++ b/src/Maybe.ts
@@ -94,8 +94,13 @@ interface MaybeTypeRef {
   /** Takes a predicate and a value, passes the value to the predicate and returns a Just if it returns true, otherwise a Nothing is returned */
   fromPredicate<T>(pred: (value: T) => boolean): (value: T) => Maybe<T>
   fromPredicate<T>(pred: (value: T) => boolean, value: T): Maybe<T>
-  fromPredicate<T, P extends T>(pred: (value: T) => value is P, value: T): Maybe<P>
-  fromPredicate<T, P extends T>(pred: (value: T) => value is P): (value: T) => Maybe<P>
+  fromPredicate<T, P extends T>(
+    pred: (value: T) => value is P,
+    value: T
+  ): Maybe<P>
+  fromPredicate<T, P extends T>(
+    pred: (value: T) => value is P
+  ): (value: T) => Maybe<P>
   /** Returns only the `Just` values in a list */
   catMaybes<T>(list: readonly Maybe<T>[]): T[]
   /** Maps over a list of values and returns a list of all resulting `Just` values */


### PR DESCRIPTION
- Replace `input.hasOwnProperty(key)` with `Object.prototype.hasOwnProperty.call(input, key)` in `Codec.ts`. This prevents runtime errors when decoding objects created via `Object.create(null)`.
- Add regression tests for prototype-less objects.
- Apply formatting and linting fixes to `Maybe.ts` and `Maybe.test.ts`.